### PR TITLE
fix(package.json): fix history dependency at "1.13.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "compression": "^1.6.0",
     "express": "^4.13.3",
     "express-session": "^1.12.1",
-    "history": "^1.13.0",
+    "history": "1.13.0",
     "file-loader": "^0.8.5",
     "hoist-non-react-statics": "^1.0.3",
     "http-proxy": "^1.12.0",


### PR DESCRIPTION
npm ERR! peerinvalid The package history@1.16.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router@1.0.2 wants history@1.13.x
npm ERR! peerinvalid Peer scroll-behavior@0.3.0 wants history@^1.12.1
